### PR TITLE
fix(completion): show only resources supporting the selected HTTP method (#12)

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -122,7 +122,9 @@ _xapicli_completion() {
       return 0
       ;;
     get|post|put|delete)
-      COMPREPLY=( $(compgen -W "$(echo "${apidef}" | jq -r 'keys[]')" -- "${cur}") )
+      # 選択されたHTTPメソッドをサポートするリソースのみ補完候補に表示 (#12)
+      COMPREPLY=( $(compgen -W "$(echo "${apidef}" | jq -r --arg m "${prev}" \
+        'to_entries[] | select(any(.value[]; .method == $m)) | .key')" -- "${cur}") )
       return 0
       ;;
     -q)


### PR DESCRIPTION
## Summary

- タブ補完で `get ` の後に全リソースが表示される問題を修正
- 選択したHTTPメソッドをサポートするリソースのみを補完候補に表示するよう変更

## Changes

`_xapicli_completion()` 内の `get|post|put|delete)` ケースで、jq の `any()` を使ってメソッドでフィルタリング:

```bash
# Before: 全リソースを表示
jq -r 'keys[]'

# After: 指定メソッドをサポートするリソースのみ表示
jq -r --arg m "${prev}" 'to_entries[] | select(any(.value[]; .method == $m)) | .key'
```

## Test plan

- [ ] `xapicli get <TAB>` → GET をサポートするリソースのみ表示 (`/pet/findByStatus` 等)
- [ ] `xapicli delete <TAB>` → DELETE をサポートするリソースのみ表示 (`/pet/{petId}`, `/store/order/{orderId}`, `/user/{username}`)
- [ ] `xapicli post <TAB>` → POST をサポートするリソースのみ表示
- [ ] Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)