### PR TITLE
fix: add GNU getopt check with clear error message

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -180,6 +180,23 @@ xapicli() {
   trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND";' ERR
 
   #
+  # GNU getopt の確認
+  #
+
+  local getopt_test
+  if getopt -T > /dev/null 2>&1; then
+    getopt_test=0
+  else
+    getopt_test=$?
+  fi
+  if [[ ${getopt_test} -ne 4 ]]; then
+    _err "GNU getopt が必要です。以下を実行してください:"
+    _err "  brew install gnu-getopt"
+    _err "  export PATH=\"/opt/homebrew/opt/gnu-getopt/bin:\$PATH\""
+    return 1
+  fi
+
+  #
   # load config and apidef file
   #
 


### PR DESCRIPTION
## Summary
- BSD getopt（macOS標準）は `-l` でロングオプションをサポートしないため、`xapicli get /store/inventory` 等を実行すると `Invalid argument: -l` という分かりにくいエラーが発生していた
- `getopt -T`（GNU getoptは終了コード4を返す）でGNU getoptの存在を確認し、BSD getoptが検出された場合は明確なエラーメッセージとインストール手順を表示するよう修正

## Test plan
- [ ] GNU getoptがPATHにある状態: `xapicli get /store/inventory` が正常動作すること
- [ ] GNU getoptがPATHにない状態: 明確なエラーメッセージ（`brew install gnu-getopt`と`export PATH=...`）が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)