### PR TITLE
fix(completion): save/restore shell options and clear RETURN trap (#18)

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -87,6 +87,13 @@ declare _XAPICLI_APIDEF_FILE_CACHE=""
 # Bash completion function for xapicli
 _xapicli_completion() {
 
+  # シェルオプションを安全な状態に設定し、xapicli()が設定したRETURNトラップをクリア (#18)
+  # set -u や set -o pipefail が有効な場合でも補完関数が途中で終了しないようにする
+  local _saved_opts
+  _saved_opts=$(set +o | grep -E 'nounset|pipefail|errexit')
+  set +euo pipefail
+  trap 'eval "$_saved_opts"' RETURN
+
   # 初期化処理
   COMPREPLY=()
   local cur prev


### PR DESCRIPTION
## Summary
- `xapicli()` が設定する RETURN トラップはグローバルに残り、`_xapicli_completion` の `return 0` にも発火していた
- ユーザーのシェルに `set -u` や `set -o pipefail` が設定されている場合、補完関数内の任意のコマンドエラーで関数が途中終了し、COMPREPLY が空のまま返っていた
- `_xapicli_completion` の冒頭で shell options を保存・安全状態に設定し、RETURN トラップで元の状態に復元するよう修正

Closes #18

## Test plan
- [ ] `set -uo pipefail` が有効な状態で `xapicli get /pet/findByStatus -q <TAB>` → `status` が候補表示される
- [ ] `xapicli()` を呼んだ直後に `-q` 補完が正しく動作する
- [ ] method/resource 補完も引き続き正常動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)