### PR TITLE
fix: support path parameters and fix ERR trap message (#20)

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -326,10 +326,11 @@ xapicli() {
           # パステンプレートマッチング: /pet/99 → /pet/{petId} (#20)
           local template_key
           template_key=$(echo "${apidef}" | jq -r --arg path "$1" '
-            keys[] | . as $k |
+            [keys[] | . as $k |
             ($k | gsub("{[^}]+}"; "[^/]+")) as $pattern |
             if ($path | test("^" + $pattern + "$")) then $k else empty end
-          ' | head -1)
+            ][0] // empty
+          ')
           if [[ -n "${template_key}" ]]; then
             resource="$1"
             shift


### PR DESCRIPTION
## Summary
- **ERR トラップ修正**: `$BASH_COMMAND` が `echo` コマンド自身に更新されてから展開されるため、`echo "$0: Error on line $LINENO: echo "$0:..."` という自己参照メッセージが出ていた。変数代入 (`cmd="${BASH_COMMAND}"`) は `$BASH_COMMAND` を更新しないことを利用して、先に値を保存するよう修正
- **パスパラメータ対応**: `/pet/99` のような実際のパスが `/pet/{petId}` テンプレートにマッチするよう、jq の `gsub` と `test` を使って正規表現マッチングを追加

Closes #20

## Test plan
- [ ] `xapicli get /pet/99` → JSON レスポンスが返ること
- [ ] `xapicli get /pet/{petId} --summary` → テンプレートのエンドポイント情報が表示されること
- [ ] `xapicli get /invalid/path` → わかりやすいエラーメッセージが表示されること（以前のような自己参照エラーではない）
- [ ] `xapicli get /store/inventory` → 引き続き正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)