### PR TITLE
feat(summary): mark required parameters with * in --summary output (#14)

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -359,8 +359,8 @@ xapicli() {
           | .key as $k
           | .value[]
           | [.method + " " + $k]
-            + (.query_parameters // [] | [.[].name] | map("-q " + .))
-            + (.post_parameters  // [] | [.[].name] | map("-p " + .))
+            + (.query_parameters // [] | [.[]] | map("-q " + .name + (if .required then "*" else "" end)))
+            + (.post_parameters  // [] | [.[]] | map("-p " + .name + (if .required then "*" else "" end)))
           | select(
               ($m == "" or (.[0] | split(" ")[0]) == $m) and
               ($r == "" or (.[0] | split(" ")[1]) == $r)


### PR DESCRIPTION
## Summary

- `--summary` の出力で必須パラメータ名に `*` を付与
- `(.query_parameters // [] | [.[].name] | map("-q " + .))` を `[.[]] | map("-q " + .name + (if .required then "*" else "" end))` に変更
- `--summary-csv` は変更なし（CSV形式のため）

## Test plan

- [ ] `xapicli --summary` で必須パラメータに `*` が表示されること
- [ ] `xapicli get /pet/findByStatus --summary` → `-q status*`
- [ ] `xapicli post /pet --summary` → `-p name*`（required）、`-p id`, `-p status`（任意）

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)