### PR TITLE
feat: support array-type POST parameters (#23)

### DIFF
--- a/.xapicli/apis/petstore-oas3.json
+++ b/.xapicli/apis/petstore-oas3.json
@@ -17,6 +17,14 @@
           "required": true
         },
         {
+          "name": "photoUrls",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "required": true
+        },
+        {
           "name": "status",
           "type": "string",
           "description": "pet status in the store",
@@ -42,6 +50,14 @@
           "name": "name",
           "type": "string",
           "example": "doggie",
+          "required": true
+        },
+        {
+          "name": "photoUrls",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "required": true
         },
         {

--- a/install-api.jq
+++ b/install-api.jq
@@ -83,7 +83,7 @@
           post_parameters: (
             .value.requestBody.content["application/json"].schema.properties // []
             | [to_entries[] | {"name": .key} + .value]
-            | map(select(.type != "object" and .type != "array"))
+            | map(select(.type != "object" and (.type != "array" or (.items.type? != "object" and .items.type? != "array"))))
           ),
           post_parameters_required: (
             .value.requestBody.content["application/json"].schema.required // {}

--- a/xapicli.sh
+++ b/xapicli.sh
@@ -287,6 +287,7 @@ xapicli() {
   local show_summary=false
   local method=""
   local resource=""
+  local apidef_resource=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --)
@@ -328,6 +329,7 @@ xapicli() {
         matched="${matched//[[:blank:]]/}"
         if [[ "${matched}" == 1 ]]; then
           resource="$1"
+          apidef_resource="$1"
           shift
         else
           # パステンプレートマッチング: /pet/99 → /pet/{petId} (#20)
@@ -340,6 +342,7 @@ xapicli() {
           ')
           if [[ -n "${template_key}" ]]; then
             resource="$1"
+            apidef_resource="${template_key}"
             shift
           else
             _err "Invalid argument: $1"
@@ -360,7 +363,7 @@ xapicli() {
           | .value[]
           | [.method + " " + $k]
             + (.query_parameters // [] | [.[]] | map("-q " + .name + (if .required then "*" else "" end)))
-            + (.post_parameters  // [] | [.[]] | map("-p " + .name + (if .required then "*" else "" end)))
+            + (.post_parameters  // [] | [.[]] | map("-p " + .name + (if .type == "array" then "[]" else "" end) + (if .required then "*" else "" end)))
           | select(
               ($m == "" or (.[0] | split(" ")[0]) == $m) and
               ($r == "" or (.[0] | split(" ")[1]) == $r)
@@ -426,10 +429,26 @@ xapicli() {
     else
       json_body="{}"
       if [[ ${#post_params[@]} -gt 0 ]]; then
+        # 配列型パラメータ名の一覧を取得 (#23)
+        local array_params
+        array_params=$(echo "${apidef}" | jq -r \
+          --arg r "${apidef_resource}" --arg m "${method}" \
+          '.[$r][]? | select(.method == $m) | .post_parameters[]? | select(.type == "array") | .name' \
+          | tr '\n' ':')
         local i
         for ((i=0; i<${#post_params[@]}; i+=2)); do
-          json_body=$(printf '%s' "${json_body}" | \
-            jq --arg k "${post_params[$i]}" --arg v "${post_params[$((i+1))]}" '. + {($k): $v}')
+          local _pk="${post_params[$i]}"
+          local _pv="${post_params[$((i+1))]}"
+          if [[ ":${array_params}:" == *":${_pk}:"* ]]; then
+            # 配列型: 初回は[$v]、2回目以降は追記
+            json_body=$(printf '%s' "${json_body}" | \
+              jq --arg k "${_pk}" --arg v "${_pv}" '
+                if has($k) then .[$k] += [$v] else . + {($k): [$v]} end
+              ')
+          else
+            json_body=$(printf '%s' "${json_body}" | \
+              jq --arg k "${_pk}" --arg v "${_pv}" '. + {($k): $v}')
+          fi
         done
       fi
     fi


### PR DESCRIPTION
## Summary

- `install-api.jq`: `type: array` かつ items がスカラー型のパラメータをフィルタアウトしないよう変更
- `xapicli.sh` (JSON builder): apidef から配列型パラメータを事前に取得し、`-p` 指定値を常に `[]` で包む。同名キーを複数回指定した場合は追記
- `xapicli.sh` (`--summary`): 配列型パラメータを `name[]` 表示（例: `photoUrls[]*`）
- `petstore-oas3.json`: 再生成（`photoUrls` が含まれるよう更新）

## Test plan

- [ ] `xapicli put /pet --summary` → `photoUrls[]*` が表示される
- [ ] `xapicli put /pet -p name Dog -p photoUrls url1 -p status available` → `{"photoUrls":["url1"],...}` (単一値でも配列)
- [ ] `xapicli put /pet -p name Dog -p photoUrls url1 -p photoUrls url2 -p status available` → `{"photoUrls":["url1","url2"],...}`
- [ ] 非配列パラメータ（`-p name Dog`）は従来通り文字列として送信される

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)