### PR TITLE
feat: support object-type POST parameters via dot notation (#24)

### DIFF
--- a/.xapicli/apis/petstore-oas3.json
+++ b/.xapicli/apis/petstore-oas3.json
@@ -17,6 +17,17 @@
           "required": true
         },
         {
+          "name": "category.id",
+          "type": "integer",
+          "format": "int64",
+          "example": 1
+        },
+        {
+          "name": "category.name",
+          "type": "string",
+          "example": "Dogs"
+        },
+        {
           "name": "photoUrls",
           "type": "array",
           "items": {
@@ -51,6 +62,17 @@
           "type": "string",
           "example": "doggie",
           "required": true
+        },
+        {
+          "name": "category.id",
+          "type": "integer",
+          "format": "int64",
+          "example": 1
+        },
+        {
+          "name": "category.name",
+          "type": "string",
+          "example": "Dogs"
         },
         {
           "name": "photoUrls",

--- a/install-api.jq
+++ b/install-api.jq
@@ -81,8 +81,16 @@
             ] // []
           ),
           post_parameters: (
-            .value.requestBody.content["application/json"].schema.properties // []
-            | [to_entries[] | {"name": .key} + .value]
+            [
+              ((.value.requestBody.content["application/json"].schema.properties // {})
+              | to_entries[])
+              | if .value.type == "object" then
+                  (.key as $parent | ((.value.properties // {}) | to_entries[]) |
+                    {"name": ($parent + "." + .key)} + .value)
+                else
+                  {"name": .key} + .value
+                end
+            ]
             | map(select(.type != "object" and (.type != "array" or (.items.type? != "object" and .items.type? != "array"))))
           ),
           post_parameters_required: (

--- a/xapicli.sh
+++ b/xapicli.sh
@@ -445,6 +445,10 @@ xapicli() {
               jq --arg k "${_pk}" --arg v "${_pv}" '
                 if has($k) then .[$k] += [$v] else . + {($k): [$v]} end
               ')
+          elif [[ "${_pk}" == *"."* ]]; then
+            # ドット記法: category.id → {"category": {"id": $v}} (#24)
+            json_body=$(printf '%s' "${json_body}" | \
+              jq --arg k "${_pk}" --arg v "${_pv}" 'setpath(($k | split(".")); $v)')
           else
             json_body=$(printf '%s' "${json_body}" | \
               jq --arg k "${_pk}" --arg v "${_pv}" '. + {($k): $v}')


### PR DESCRIPTION
## Summary

- `install-api.jq`: `type: object` なパラメータを1階層フラット化してドット記法のエントリに変換（例: `category` → `category.id`, `category.name`）
- `xapicli.sh`: ドット記法のキーを `jq setpath` でネスト JSON に展開（例: `-p category.id 2 -p category.name Dogs` → `{"category":{"id":"2","name":"Dogs"}}`）
- `petstore-oas3.json`: 再生成（`category.id` / `category.name` を含む）

## Test plan

- [ ] `xapicli put /pet --summary` → `category.id`, `category.name` が表示される
- [ ] `xapicli put /pet -p id 1 -p name Dog -p category.id 2 -p category.name Dogs -p photoUrls url1 -p status available` → `{"category":{"id":"2","name":"Dogs"},...}` が返る
- [ ] 複数の `category.*` フィールドを指定したとき同一オブジェクトにマージされる
- [ ] 非オブジェクト・非配列パラメータは従来通り動作する

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)