### PR TITLE
feat: suggest enum values in tab completion for -q/-p (#15)

### DIFF
--- a/.xapicli/apis/petstore-oas3.json
+++ b/.xapicli/apis/petstore-oas3.json
@@ -102,7 +102,12 @@
         {
           "name": "status",
           "type": "string",
-          "required": true
+          "required": true,
+          "enum": [
+            "available",
+            "pending",
+            "sold"
+          ]
         }
       ]
     }
@@ -124,12 +129,14 @@
         {
           "name": "name",
           "type": "string",
-          "required": false
+          "required": false,
+          "enum": []
         },
         {
           "name": "status",
           "type": "string",
-          "required": false
+          "required": false,
+          "enum": []
         }
       ],
       "post_parameters": []
@@ -146,7 +153,8 @@
         {
           "name": "additionalMetadata",
           "type": "string",
-          "required": false
+          "required": false,
+          "enum": []
         }
       ],
       "post_parameters": []
@@ -279,12 +287,14 @@
         {
           "name": "username",
           "type": "string",
-          "required": false
+          "required": false,
+          "enum": []
         },
         {
           "name": "password",
           "type": "string",
-          "required": false
+          "required": false,
+          "enum": []
         }
       ]
     }

--- a/install-api.jq
+++ b/install-api.jq
@@ -77,7 +77,7 @@
               .value.parameters[]?
               | select(.in == "query")
               | select(.schema.type != "object" and .schema.type != "array")
-              | { name: .name, type: .schema.type, required: (.required // false) }
+              | { name: .name, type: .schema.type, required: (.required // false), enum: (.schema.enum // []) }
             ] // []
           ),
           post_parameters: (

--- a/xapicli.sh
+++ b/xapicli.sh
@@ -123,6 +123,27 @@ _xapicli_completion() {
 
   local http_methods="get post put delete"
 
+  # -q/-p の値補完: 直前が param 名で2つ前が -q/-p なら enum 値を候補に (#15)
+  if [[ COMP_CWORD -ge 4 ]]; then
+    local _flag="${COMP_WORDS[COMP_CWORD-2]}"
+    if [[ "${_flag}" == "-q" || "${_flag}" == "-p" ]]; then
+      local _method="${COMP_WORDS[1]}"
+      local _res="${COMP_WORDS[2]}"
+      local _param="${prev}"
+      local _key
+      [[ "${_flag}" == "-q" ]] && _key="query_parameters" || _key="post_parameters"
+      local _enums
+      _enums=$(echo "${apidef}" | jq -r \
+        --arg res "${_res}" --arg meth "${_method}" \
+        --arg p "${_param}" --arg k "${_key}" \
+        '.[$res][]? | select(.method == $meth) | .[$k][] | select(.name == $p) | .enum[]?')
+      if [[ -n "${_enums}" ]]; then
+        COMPREPLY=( $(compgen -W "${_enums}" -- "${cur}") )
+        return 0
+      fi
+    fi
+  fi
+
   case "${prev}" in
     xapicli)
       COMPREPLY=( $(compgen -W "${http_methods}" -- "${cur}") )


### PR DESCRIPTION
## Summary

- `install-api.jq`: `query_parameters` のエントリに `enum: (.schema.enum // [])` を追加（`post_parameters` は既に `.value` 展開で `enum` を含んでいるため変更不要）
- `xapicli.sh` (`_xapicli_completion`): メインの `case` ブロック前に、`COMP_WORDS[COMP_CWORD-2]` が `-q`/`-p` の場合に apidef から `enum` 値を取得して `COMPREPLY` にセットする処理を追加
- `petstore-oas3.json`: 再生成

## Test plan

- [ ] `xapicli get /pet/findByStatus -q status <TAB>` → `available pending sold` が表示される
- [ ] `xapicli get /pet/findByStatus -q status av<TAB>` → `available` のみ表示される
- [ ] `xapicli put /pet -p status <TAB>` → `available pending sold` が表示される
- [ ] enum がないパラメータ（`-p name <TAB>`）では何も補完されない

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)