### PR TITLE
feat: suggest -q/-p/--summary/--help/-d after resource path in completion (#13)

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -177,6 +177,20 @@ _xapicli_completion() {
       COMPREPLY=( $(compgen -W "${post_params}" -- "${cur}") )
       return 0
       ;;
+    /*)
+      # resource path: show applicable options (#13)
+      local _method="${COMP_WORDS[1]}"
+      local _resource="${prev}"
+      local _flags
+      _flags=$(echo "${apidef}" | jq -r --arg res "${_resource}" --arg m "${_method}" '
+        [(.[$res][]? | select(.method == $m)) as $ep |
+          (if (($ep.query_parameters // []) | length) > 0 then "-q" else empty end),
+          (if (($ep.post_parameters  // []) | length) > 0 then "-p" else empty end)
+        ] | unique | .[]
+      ')
+      COMPREPLY=( $(compgen -W "${_flags} --summary --help -d" -- "${cur}") )
+      return 0
+      ;;
   esac
 }
 


### PR DESCRIPTION
## Summary

`_xapicli_completion` に `/*` ケースを追加。`prev` がリソースパス（`/` で始まる）のとき、API 定義を参照して以下のオプションを候補として表示:

- `query_parameters` を持つエンドポイント → `-q` を追加
- `post_parameters` を持つエンドポイント → `-p` を追加
- 常に `--summary`, `--help`, `-d` を追加

## Test plan

- [ ] `xapicli get /pet/findByStatus <TAB>` → `-q --summary --help -d`
- [ ] `xapicli post /pet <TAB>` → `-p --summary --help -d`
- [ ] `xapicli get /store/inventory <TAB>` (クエリ/POSTパラメータなし) → `--summary --help -d`
- [ ] `xapicli get /pet/findByStatus --<TAB>` → `--summary --help`（前方一致）

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)