### PR TITLE
feat: add -h (alias for --help) and --version options (#31)

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -23,7 +23,8 @@ trap 'rc=$?; cmd="${BASH_COMMAND}"; echo >&2 "$0: Error on line $LINENO: $cmd (e
 # constants
 #
 
-declare readonly LONG_OPTS="help,summary::,summary-csv"
+declare readonly LONG_OPTS="help,summary::,summary-csv,version"
+declare readonly _XAPICLI_VERSION="0.1.0"
 
 # escape sequences for colored output on the console
 RSET="\e[0m"  # reset
@@ -238,6 +239,20 @@ xapicli() {
     return 1
   fi
 
+  # -h/--help/--version は config ロード前に処理 (#31)
+  for _arg in "$@"; do
+    case "${_arg}" in
+      -h|--help)
+        _usage
+        return 0
+        ;;
+      --version)
+        echo "xapicli ${_XAPICLI_VERSION}"
+        return 0
+        ;;
+    esac
+  done
+
   #
   # load config and apidef file
   #
@@ -280,6 +295,14 @@ xapicli() {
   local -a clean_args=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
+      -h|--help)
+        _usage
+        return 0
+        ;;
+      --version)
+        echo "xapicli ${_XAPICLI_VERSION}"
+        return 0
+        ;;
       -q)
         shift
         if [[ $# -lt 2 ]]; then


### PR DESCRIPTION
## Summary

- `_XAPICLI_VERSION="0.1.0"` 定数を追加
- `LONG_OPTS` に `version` を追加（getopt 互換性のため）
- config 読み込み前の事前スキャンで `-h`/`--help`/`--version` を処理（config 未設定環境でも動作）
- pre-processing ループにも同ケースを追加（引数末尾での指定にも対応）

## Test plan

- [ ] `xapicli --version` → `xapicli 0.1.0`
- [ ] `xapicli -h` → `--help` と同じ使い方表示
- [ ] `xapicli --help` → 従来通り動作
- [ ] config 未設定環境での `xapicli --version` → エラーなく `xapicli 0.1.0` を表示

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
