### PR TITLE
fix: use ANSI-C quoting for color escape sequences (#35)

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -27,9 +27,9 @@ declare readonly LONG_OPTS="help,summary::,summary-csv,version"
 declare readonly _XAPICLI_VERSION="0.1.0"
 
 # escape sequences for colored output on the console
-RSET="\e[0m"  # reset
-FRED="\e[31m" # foreground red
-FGRN="\e[32m" # foreground green
+RSET=$'\e[0m'  # reset
+FRED=$'\e[31m' # foreground red
+FGRN=$'\e[32m' # foreground green
 #FYEL="\e[43m" # background yellow
 
 #


### PR DESCRIPTION
## Summary

- `FRED`/`RSET`/`FGRN` の変数定義を `"\e[..."` から `$'\e[...'` に変更
- ダブルクォートでは `\e` がリテラル2文字として格納されるため、`echo -e` でも正しく色が表示されないケースがあった
- `$'...'`（ANSI-C quoting）を使うことで代入時点でESC文字に変換され、bash 3.2でも確実に動作する

Closes #35

## Test plan

- [ ] `source xapicli.sh` 後に GNU getopt が PATH に含まれない状態でエラーを発生させ、カラー出力が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)