### PR TITLE
feat: add custom HTTP header support via -H flag and XAPICLI_CUSTOM_HEADER env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,11 +105,14 @@ Options:
   --summary[=<resource>]    Print available endpoints; required params marked *, array params marked []
   --summary-csv             Print endpoints in CSV format
 Params:
+  -H <header: value>        Custom HTTP header (repeatable)
   -q <name> <value>         Query parameter (repeatable)
   -p <name> <value>         Body parameter (repeatable); builds a JSON object
                               Repeat the same name for array params: -p tags a -p tags b → {"tags":["a","b"]}
                               Use dot notation for object params: -p category.id 1 → {"category":{"id":"1"}}
   -d <json>                 Raw JSON body (overrides -p)
+Env:
+  XAPICLI_CUSTOM_HEADER     Custom HTTP header(s), newline-separated, applied to every request
 ```
 
 ## Code Modification Workflow
@@ -131,4 +134,4 @@ Individual instructions take precedence — e.g. "skip the issue", "don't open a
 - Array parameters are supported only when items are scalar types; arrays of objects are not supported
 - Object parameters are supported one level deep via dot notation; deeper nesting is not supported
 - `explode` is not supported
-- Authentication headers must be added manually (not supported natively)
+- Authentication headers can be passed via `-H "Authorization: Bearer token"` or the `XAPICLI_CUSTOM_HEADER` env var

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Methods:
 
 Options:
   --init <spec-file>     Initialize API from an OpenAPI spec file
+  -H <header: value>     Custom HTTP header (repeatable)
   -q <name> <value>      Query parameter (repeatable)
   -p <name> <value>      Body parameter (repeatable); builds a JSON object
                            - Repeat the same name to build a JSON array:
@@ -209,6 +210,11 @@ Options:
                            Required params are marked with *, array params with []
   --summary-csv          Print endpoints in CSV format
   --help                 Show usage
+
+Environment variables:
+  XAPICLI_CUSTOM_HEADER  Custom HTTP header(s) applied to every request.
+                           Use newlines to specify multiple headers:
+                           export XAPICLI_CUSTOM_HEADER=$'Authorization: Bearer token\nX-Tenant: acme'
 ```
 
 ### Examples
@@ -253,7 +259,7 @@ xapicli delete /pet/1
 - Only `application/json` request bodies are recognized
 - Array parameters are supported only when items are scalar types (string, integer, etc.); arrays of objects are not supported
 - Object parameters are supported one level deep via dot notation; deeper nesting is not supported
-- Authentication headers must be added manually (not supported natively)
+- Authentication headers can be passed via `-H "Authorization: Bearer token"` or the `XAPICLI_CUSTOM_HEADER` env var
 - `explode` and deeply nested object constraints are not enforced
 
 ---

--- a/xapicli.sh
+++ b/xapicli.sh
@@ -79,6 +79,7 @@ _usage()
   _msg "  --summary[=<resource>]    Print available endpoints"
   _msg "  --summary-csv             Print endpoints in CSV format"
   _msg "Params:"
+  _msg "  -H <header: value>        Custom HTTP header (repeatable)"
   _msg "  -q <name> <value>         Query parameter (repeatable)"
   _msg "  -p <name> <value>         Body parameter (repeatable)"
   _msg "  -d <json>                 Raw JSON body (overrides -p)"
@@ -349,7 +350,7 @@ _xapicli_completion() {
           (if (($ep.post_parameters  // []) | length) > 0 then "-p" else empty end)
         ] | unique | .[]
       ')
-      COMPREPLY=( $(compgen -W "${_flags} --summary --help -d" -- "${cur}") )
+      COMPREPLY=( $(compgen -W "${_flags} --summary --help -H -d" -- "${cur}") )
       return 0
       ;;
   esac
@@ -456,8 +457,10 @@ xapicli() {
   #
 
   # Pre-process: -q/-p はそれぞれ <name> <value> の2引数、-d は <json> の1引数を取る (#3, #4)
+  # -H は <header: value> の1引数 (#39)
   local -a query_params=()
   local -a post_params=()
+  local -a custom_headers=()
   local raw_body=""
   local -a clean_args=()
   while [[ $# -gt 0 ]]; do
@@ -469,6 +472,15 @@ xapicli() {
       --version)
         echo "xapicli ${_XAPICLI_VERSION}"
         return 0
+        ;;
+      -H)
+        shift
+        if [[ $# -lt 1 ]]; then
+          _err "'-H' requires one argument: <header: value>"
+          return 1
+        fi
+        custom_headers+=("$1")
+        shift
         ;;
       -q)
         shift
@@ -503,6 +515,13 @@ xapicli() {
         ;;
     esac
   done
+
+  # XAPICLI_CUSTOM_HEADER 環境変数からカスタムヘッダーを追加 (改行区切り) (#39)
+  if [[ -n "${XAPICLI_CUSTOM_HEADER:-}" ]]; then
+    while IFS= read -r _hdr; do
+      [[ -n "${_hdr}" ]] && custom_headers+=("${_hdr}")
+    done <<< "${XAPICLI_CUSTOM_HEADER}"
+  fi
 
   local args
   args=$(getopt -o "" -l "${LONG_OPTS}" -- ${clean_args[@]+"${clean_args[@]}"}) || return 1
@@ -641,11 +660,20 @@ xapicli() {
     full_url+="?${query_string}"
   fi
 
+  # カスタムヘッダーを curl の引数配列に変換 (#39)
+  local -a curl_header_args=()
+  local _ch
+  for _ch in ${custom_headers[@]+"${custom_headers[@]}"}; do
+    curl_header_args+=("-H" "${_ch}")
+  done
+
   # HTTPリクエストの実行 (#1)
   local method_upper
   method_upper=$(printf '%s' "${method}" | tr '[:lower:]' '[:upper:]')
   if [[ "${method}" == "get" || "${method}" == "delete" ]]; then
-    curl -s -X "${method_upper}" "${full_url}"
+    curl -s -X "${method_upper}" \
+      ${curl_header_args[@]+"${curl_header_args[@]}"} \
+      "${full_url}"
   else
     # -d で生JSONが指定された場合はそれを使用、なければ -p からJSONを組み立て
     local json_body
@@ -683,6 +711,7 @@ xapicli() {
     fi
     curl -s -X "${method_upper}" "${full_url}" \
       -H "Content-Type: application/json" \
+      ${curl_header_args[@]+"${curl_header_args[@]}"} \
       -d "${json_body}"
   fi
 }


### PR DESCRIPTION
## Summary
- Add `-H <header: value>` option (repeatable) for per-request custom headers
- Add `XAPICLI_CUSTOM_HEADER` env var for persistent headers (newline-separated for multiple values)
- Both sources are merged and applied to all HTTP methods (GET, DELETE, POST, PUT)
- `-H` added to tab completion candidates after a resource path

### Examples
```bash
# Per-request header
xapicli get /pet/1 -H "Authorization: Bearer <token>"

# Multiple headers
xapicli post /pet -H "Authorization: Bearer <token>" -H "X-Tenant: acme" -p name "Dog"

# Via env var (persistent)
export XAPICLI_CUSTOM_HEADER="Authorization: Bearer <token>"
xapicli get /pet/1

# Multiple headers via env var (newline-separated)
export XAPICLI_CUSTOM_HEADER=$'Authorization: Bearer <token>\nX-Tenant: acme'
xapicli get /pet/1

# Both combined (-H flags + env var)
XAPICLI_CUSTOM_HEADER="X-Tenant: acme" xapicli get /pet/1 -H "Authorization: Bearer <token>"
```

Closes #39

## Test plan
- [ ] `-H "Authorization: Bearer token"` is passed to curl for GET/DELETE/POST/PUT
- [ ] Multiple `-H` flags are all passed to curl
- [ ] `XAPICLI_CUSTOM_HEADER` single-line value is applied
- [ ] `XAPICLI_CUSTOM_HEADER` multi-line value sends multiple headers
- [ ] `-H` flags and env var headers are merged correctly
- [ ] Missing value for `-H` prints an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)