### PR TITLE
feat: add --conf option to display configuration and env var settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Options:
   -h, --help                Show this help message
   --version                 Show version
   --init <spec-file>        Initialize API from an OpenAPI spec file
+  --conf                    Show current configuration and env var settings
   --summary[=<resource>]    Print available endpoints; required params marked *, array params marked []
   --summary-csv             Print endpoints in CSV format
 Params:

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Methods:
 
 Options:
   --init <spec-file>     Initialize API from an OpenAPI spec file
+  --conf                 Show current configuration and env var settings
   -H <header: value>     Custom HTTP header (repeatable)
   -q <name> <value>      Query parameter (repeatable)
   -p <name> <value>      Body parameter (repeatable); builds a JSON object

--- a/xapicli.sh
+++ b/xapicli.sh
@@ -76,6 +76,7 @@ _usage()
   _msg "  -h, --help                Show this help message"
   _msg "  --version                 Show version"
   _msg "  --init <spec-file>        Initialize API from an OpenAPI spec file"
+  _msg "  --conf                    Show current configuration and env var settings"
   _msg "  --summary[=<resource>]    Print available endpoints"
   _msg "  --summary-csv             Print endpoints in CSV format"
   _msg "Params:"
@@ -400,7 +401,7 @@ xapicli() {
     return 1
   fi
 
-  # -h/--help/--version/--init は config ロード前に処理 (#31, #38)
+  # -h/--help/--version/--init/--conf は config ロード前に処理 (#31, #38, #43)
   local _i=1
   while [[ $_i -le $# ]]; do
     case "${!_i}" in
@@ -416,6 +417,27 @@ xapicli() {
         _i=$((_i + 1))
         _xapicli_init "${!_i:-}"
         return $?
+        ;;
+      --conf)
+        local _conf_dir="${XAPICLI_CONF_DIR:-$HOME/.xapicli}"
+        _msg "Config file  : ${_conf_dir}/xapicli.conf"
+        _msg "API def dir  : ${_conf_dir}/apis/"
+        _msg ""
+        _msg "XAPICLI_CONF_DIR      : ${XAPICLI_CONF_DIR:-(not set)}"
+        if [[ -n "${XAPICLI_CUSTOM_HEADER:-}" ]]; then
+          local _first=true
+          while IFS= read -r _hdr_line; do
+            if [[ "${_first}" == "true" ]]; then
+              _msg "XAPICLI_CUSTOM_HEADER : ${_hdr_line}"
+              _first=false
+            else
+              _msg "                       ${_hdr_line}"
+            fi
+          done <<< "${XAPICLI_CUSTOM_HEADER}"
+        else
+          _msg "XAPICLI_CUSTOM_HEADER : (not set)"
+        fi
+        return 0
         ;;
     esac
     _i=$((_i + 1))


### PR DESCRIPTION
## Summary
- Add `xapicli --conf` option that prints the active runtime configuration
- Displayed information:
  - Full path of `xapicli.conf` being used
  - Full path of `apis/` directory
  - Value of `XAPICLI_CONF_DIR` (or `(not set)` if unset)
  - Value of `XAPICLI_CUSTOM_HEADER` (or `(not set)` if unset); multi-line values are displayed with indented continuation lines

### Example output
```
Config file  : /Users/alice/.xapicli/xapicli.conf
API def dir  : /Users/alice/.xapicli/apis/

XAPICLI_CONF_DIR      : /Users/alice/.xapicli
XAPICLI_CUSTOM_HEADER : Authorization: Bearer token
                       X-Tenant: acme
```

Closes #43

## Test plan
- [ ] `xapicli --conf` with no env vars set shows `(not set)` for both vars and uses `$HOME/.xapicli`
- [ ] `xapicli --conf` with `XAPICLI_CONF_DIR` set shows the correct path
- [ ] `xapicli --conf` with single-line `XAPICLI_CUSTOM_HEADER` shows the value
- [ ] `xapicli --conf` with multi-line `XAPICLI_CUSTOM_HEADER` shows indented continuation lines
- [ ] `--conf` appears in `xapicli --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)