### PR TITLE
feat: display xapicli.conf contents in --conf output

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -420,7 +420,8 @@ xapicli() {
         ;;
       --conf)
         local _conf_dir="${XAPICLI_CONF_DIR:-$HOME/.xapicli}"
-        _msg "Config file  : ${_conf_dir}/xapicli.conf"
+        local _conf_file="${_conf_dir}/xapicli.conf"
+        _msg "Config file  : ${_conf_file}"
         _msg "API def dir  : ${_conf_dir}/apis/"
         _msg ""
         _msg "XAPICLI_CONF_DIR      : ${XAPICLI_CONF_DIR:-(not set)}"
@@ -436,6 +437,13 @@ xapicli() {
           done <<< "${XAPICLI_CUSTOM_HEADER}"
         else
           _msg "XAPICLI_CUSTOM_HEADER : (not set)"
+        fi
+        _msg ""
+        _msg "--- xapicli.conf ---"
+        if [[ -f "${_conf_file}" ]]; then
+          _msg "$(cat "${_conf_file}")"
+        else
+          _msg "(file not found)"
         fi
         return 0
         ;;


### PR DESCRIPTION
## Summary
Append the contents of the active `xapicli.conf` to the output of `xapicli --conf`. If the file does not exist, print `(file not found)` instead.

### Example output
```
Config file  : /Users/alice/.xapicli/xapicli.conf
API def dir  : /Users/alice/.xapicli/apis/

XAPICLI_CONF_DIR      : /Users/alice/.xapicli
XAPICLI_CUSTOM_HEADER : (not set)

--- xapicli.conf ---
{
  "default": "petstore",
  "petstore": {
    "openapispec": "../examples/petstore-oas3.json",
    "apidef": "petstore-oas3.json",
    "url": "http://localhost:8080/api/v3/"
  }
}
```

Closes #45

## Test plan
- [ ] `xapicli --conf` with a valid config file shows its contents after the env var section
- [ ] `xapicli --conf` when config file does not exist shows `(file not found)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)