### PR TITLE
fix: validate OpenAPI spec before jq processing in --init

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -126,6 +126,13 @@ _xapicli_init() {
     return 1
   }
 
+  # Validate that the resolved JSON is a proper OpenAPI spec (#47)
+  if ! echo "${resolved_json}" | jq -e 'has("paths")' > /dev/null 2>&1; then
+    _err "The file does not appear to be a valid OpenAPI spec (missing 'paths' key)"
+    _err "Pass the original OpenAPI spec file, not the generated API definition in ${apis_dir}/"
+    return 1
+  fi
+
   _info "Generating API definition ..."
   local tmp_filter
   tmp_filter=$(mktemp)


### PR DESCRIPTION
## Root Cause

When `xapicli --init` is run a second time and accidentally receives the **generated API definition file** (e.g. `.xapicli/apis/petstore-oas3.json`) instead of the original OpenAPI spec, the following sequence occurs:

1. `json-refs resolve` succeeds (exit 0) — the apidef is valid JSON
2. The generated apidef format is `{"/pet": [...], ...}` — no `.paths` key
3. The jq filter does `.paths | to_entries` → fails with cryptic error:
   ```
   jq: error (at <stdin>:367): null (null) has no keys
   Failed to generate API definition
   ```

The number **367** matches exactly the line count of the generated `petstore-oas3.json` apidef file.

## Fix

After `json-refs resolve`, validate that the resolved JSON has a top-level `paths` key. If missing, print a helpful error message:

```
The file does not appear to be a valid OpenAPI spec (missing 'paths' key)
Pass the original OpenAPI spec file, not the generated API definition in <apis_dir>/
```

## Before / After

**Before:**
```
Resolving $ref references in .xapicli/apis/petstore-oas3.json ...
Generating API definition ...
jq: error (at <stdin>:367): null (null) has no keys
Failed to generate API definition
```

**After:**
```
Resolving $ref references in .xapicli/apis/petstore-oas3.json ...
The file does not appear to be a valid OpenAPI spec (missing 'paths' key)
Pass the original OpenAPI spec file, not the generated API definition in .xapicli/apis/
```

Closes #47

## Test plan
- [ ] `xapicli --init .xapicli/apis/petstore-oas3.json` (generated apidef) → shows helpful error, exits 1
- [ ] `xapicli --init examples/petstore-oas3.json` (original spec) → works correctly
- [ ] `xapicli --init spec-without-paths.json` (any JSON without `paths`) → shows helpful error, exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)