### PR TITLE
feat: add --use <api-name> option to switch the active API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Options:
   -h, --help                Show this help message
   --version                 Show version
   --init <spec-file>        Initialize API from an OpenAPI spec file
+  --use <api-name>          Switch the active API (updates 'default' in xapicli.conf)
   --conf                    Show current configuration and env var settings
   --summary[=<resource>]    Print available endpoints; required params marked *, array params marked []
   --summary-csv             Print endpoints in CSV format

--- a/README.md
+++ b/README.md
@@ -186,6 +186,22 @@ If the spec contains a `servers[0].url` entry, it is used automatically. Otherwi
 }
 ```
 
+### Managing multiple APIs
+
+Multiple APIs can be registered by running `--init` for each spec. Use `--use` to switch between them:
+
+```bash
+# Register multiple APIs
+xapicli --init petstore.json
+xapicli --init myapi.json
+
+# Switch the active API
+xapicli --use myapi
+
+# See all registered APIs and the current default
+xapicli --conf
+```
+
 ---
 
 ## Usage Reference
@@ -198,6 +214,7 @@ Methods:
 
 Options:
   --init <spec-file>     Initialize API from an OpenAPI spec file
+  --use <api-name>       Switch the active API (updates 'default' in xapicli.conf)
   --conf                 Show current configuration and env var settings
   -H <header: value>     Custom HTTP header (repeatable)
   -q <name> <value>      Query parameter (repeatable)

--- a/xapicli.sh
+++ b/xapicli.sh
@@ -76,6 +76,7 @@ _usage()
   _msg "  -h, --help                Show this help message"
   _msg "  --version                 Show version"
   _msg "  --init <spec-file>        Initialize API from an OpenAPI spec file"
+  _msg "  --use <api-name>          Switch the active API (updates 'default' in xapicli.conf)"
   _msg "  --conf                    Show current configuration and env var settings"
   _msg "  --summary[=<resource>]    Print available endpoints"
   _msg "  --summary-csv             Print endpoints in CSV format"
@@ -424,6 +425,33 @@ xapicli() {
         _i=$((_i + 1))
         _xapicli_init "${!_i:-}"
         return $?
+        ;;
+      --use)
+        _i=$((_i + 1))
+        local _use_name="${!_i:-}"
+        if [[ -z "${_use_name}" ]]; then
+          _err "--use requires an API name argument"
+          _msg "Usage: xapicli --use <api-name>"
+          return 1
+        fi
+        local _use_conf_dir="${XAPICLI_CONF_DIR:-$HOME/.xapicli}"
+        local _use_conf_file="${_use_conf_dir}/xapicli.conf"
+        if [[ ! -f "${_use_conf_file}" ]]; then
+          _err "Config file not found: ${_use_conf_file}"
+          return 1
+        fi
+        if ! jq -e --arg n "${_use_name}" 'has($n) and ($n != "default")' "${_use_conf_file}" > /dev/null 2>&1; then
+          _err "API '${_use_name}' not found in ${_use_conf_file}"
+          _msg "Available APIs:"
+          jq -r 'keys[] | select(. != "default") | "  " + .' "${_use_conf_file}" >&2
+          return 1
+        fi
+        local _use_tmp
+        _use_tmp=$(mktemp)
+        jq --arg n "${_use_name}" '.default = $n' "${_use_conf_file}" > "${_use_tmp}" \
+          && mv "${_use_tmp}" "${_use_conf_file}"
+        _info "Switched to API: ${_use_name}"
+        return 0
         ;;
       --conf)
         local _conf_dir="${XAPICLI_CONF_DIR:-$HOME/.xapicli}"


### PR DESCRIPTION
## Summary
- Add `xapicli --use <api-name>` to switch the active API by updating `"default"` in `xapicli.conf`
- Validates the given name against registered APIs; lists available names on error
- Update `--help`, README.md (including a new "Managing multiple APIs" section), and CLAUDE.md

### Examples
```bash
# Register two APIs
xapicli --init petstore.json
xapicli --init myapi.json

# Switch to myapi
xapicli --use myapi

# Error: unknown name → lists available APIs
xapicli --use typo
#  API 'typo' not found in ...
# Available APIs:
#   myapi
#   petstore

# Confirm
xapicli --conf
```

Closes #49

## Test plan
- [ ] `xapicli --use <registered-name>` updates `"default"` in `xapicli.conf` and prints confirmation
- [ ] `xapicli --use <unknown-name>` prints error and lists available API names, exits 1
- [ ] `xapicli --use` (no argument) prints usage hint, exits 1
- [ ] `xapicli --use default` is rejected (reserved key)
- [ ] `--use` appears in `xapicli --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)