### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -25,7 +25,7 @@ trap 'rc=$?; cmd="${BASH_COMMAND}"; echo >&2 "$0: Error on line $LINENO: $cmd (e
 
 declare readonly LONG_OPTS="help,summary::,summary-csv,version"
 declare readonly LONG_OPTS_INIT="init:"
-declare readonly _XAPICLI_VERSION="0.1.0"
+declare readonly _XAPICLI_VERSION="0.4.0"
 
 # escape sequences for colored output on the console
 RSET=$'\e[0m'  # reset


### PR DESCRIPTION
## Summary
- Bumps `_XAPICLI_VERSION` from `0.1.0` to `0.4.0`

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)