### PR TITLE
fix: replace HISTFILE="" with unset HISTFILE for Git Bash compatibility

### DIFF
--- a/xapicli.sh
+++ b/xapicli.sh
@@ -11,7 +11,7 @@ OLD_SET=$(set +o | grep -e nounset -e pipefail)
 # 本スクリプトでの設定
 IFS=$'\t\n'
 set -uo pipefail
-HISTFILE=""
+unset HISTFILE
 
 # スクリプト終了時(source実行時)、IFSとオプション設定を元に戻す
 trap 'IFS="$OLD_IFS"; eval "$OLD_SET"' RETURN


### PR DESCRIPTION
## Summary
- Replaces `HISTFILE=""` with `unset HISTFILE` on line 14 of `xapicli.sh`

## Root Cause
On Windows Git Bash, `HISTFILE=""` is treated as an empty filename. When bash runs `history -a` internally, it tries to write to that empty path and fails:
```
bash: history: : cannot create: No such file or directory
```
The ERR trap then fires on every subsequent command in the same terminal session, breaking the shell environment entirely.

## Fix
`unset HISTFILE` properly disables history file usage without leaving an empty path that Git Bash tries to write to.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)